### PR TITLE
Use cli pluralization for error message.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Added the `palettes.symbol` option to set the symbol used for colour previews. See `?"palettes-options"` for details.
 
+- Improved error message for invalid colours to support singular and plural grammar (@olivroy, #32)
+
 # palettes 0.1.1
 
 This is a small patch release that fixes a typo in the "Creating a Colour Package" vignette, replacing the non-existent `pal_brewer()` function with the intended `pal_ramp()` function.

--- a/R/colour.R
+++ b/R/colour.R
@@ -40,11 +40,11 @@ validate_colour <- function(x) {
   values <- vec_data(x)
   valid_colours <- is_valid_colour(values)
 
-  if (any(!valid_colours) & vec_size(values) != 0) {
-    invalid_colours <- paste(paste0("\"", values[!valid_colours], "\""), collapse = ", ")
-    rlang::abort(c(
+  if (!all(valid_colours) && vec_size(values) != 0) {
+    invalid_colours <- values[!valid_colours]
+    cli::cli_abort(c(
       "All `x` values must be hexadecimal strings or colour names.",
-      "x" = paste0("The following values are not valid colours: ", invalid_colours, ".")
+      "x" = "The following value{?s} {?is/are} not {?a/} valid colour{?s}: {.str {invalid_colours}}."
     ))
   }
 


### PR DESCRIPTION
Tweak error message slightly to take advantage of cli pluralization. I tweaked the condition a little.

If a single value is wrong: ✖ The following value is not a valid colour: "asa".

If many values are wrong: ✖ The following values are not valid colours: "asa" and "redg".
