### PR TITLE
Compatability with ggplot2 4.0.0

### DIFF
--- a/R/ggplot2-scales.R
+++ b/R/ggplot2-scales.R
@@ -41,14 +41,14 @@ scale_fill_palette_d <- function(palette, direction = 1, ...) {
 
 #' @export
 #' @rdname scale_colour_palette_d
-scale_colour_palette_c <- function(palette, direction = 1, ...) {
-  scale_palette_c(aesthetics = "colour", palette, direction, ...)
+scale_colour_palette_c <- function(palette, direction = 1, ..., na.value = NA) {
+  scale_palette_c(aesthetics = "colour", palette, direction, ..., na.value = na.value)
 }
 
 #' @export
 #' @rdname scale_colour_palette_d
-scale_fill_palette_c <- function(palette, direction = 1, ...) {
-  scale_palette_c(aesthetics = "fill", palette, direction, ...)
+scale_fill_palette_c <- function(palette, direction = 1, ..., na.value = NA) {
+  scale_palette_c(aesthetics = "fill", palette, direction, ..., na.value = na.value)
 }
 
 #' @export

--- a/man/scale_colour_palette_d.Rd
+++ b/man/scale_colour_palette_d.Rd
@@ -16,9 +16,9 @@ scale_colour_palette_d(palette, direction = 1, ...)
 
 scale_fill_palette_d(palette, direction = 1, ...)
 
-scale_colour_palette_c(palette, direction = 1, ...)
+scale_colour_palette_c(palette, direction = 1, ..., na.value = NA)
 
-scale_fill_palette_c(palette, direction = 1, ...)
+scale_fill_palette_c(palette, direction = 1, ..., na.value = NA)
 
 scale_colour_palette_b(palette, direction = 1, ...)
 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was that ggplot2 is now more strict about types, which would require a scale's `na.value` to be of the same type as (or coercable to) the palette outcome.
This PR sets logical `NA`s as `na.value`, which replaces `NA_real_` that was the default for continuous scales. The logical `NA`s can then be cast to characters without problem.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun